### PR TITLE
Update candle dependency to version 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,8 @@ test_masked_fill = ["masked_fill", "triangular", "logical_not"]
 
 
 [dependencies]
-candle-core = "0.3"
-candle-nn = "0.3"
+candle-core = "0.4"
+candle-nn = "0.4"
 num-traits = "0.2"
 
 


### PR DESCRIPTION
I'd like to use this library with the latest minor version of the core library! I can run this on a CUDA machine later today if manual testing is needed.